### PR TITLE
feature(docker): arm32v7 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,4 +17,4 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - feature/arm32v7_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,4 +17,4 @@ workflows:
           filters:
             branches:
               only:
-                - feature/arm32v7_image
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+orbs:
+  docker-buildx: foodles/docker-buildx@0.0.1
+
+workflows:
+  version: 2
+  build-and-publish-docker-image:
+    jobs:
+      - docker-buildx/publish:
+          name: build_deploy_docker_dev
+          context: docker-publishing
+          checkout: true
+          attach-workspace: true
+          image: foodlestech/logzio-docker-collector-logs
+          tag: develop
+          filters:
+            branches:
+              only:
+                - develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.7-alpine
+FROM arm32v7/python:3.7-alpine
 
-ENV PACKAGE=filebeat-6.5.4-linux-x86_64.tar.gz
+ENV PACKAGE=filebeat-6.5.4-linux-arm32v7.tar.gz
 
 
 RUN mkdir -p /opt/filebeat/docker-colletor-logs && \
@@ -11,9 +11,9 @@ WORKDIR /opt/filebeat
 COPY requirements.txt docker-colletor-logs/requirements.txt
 COPY default_filebeat.yml docker-colletor-logs/default_filebeat.yml
 COPY filebeat-yml-script.py docker-colletor-logs/filebeat-yml-script.py
+COPY $PACKAGE $PACKAGE
 
-RUN apk add --update --no-cache libc6-compat wget tar && \
-    wget https://artifacts.elastic.co/downloads/beats/filebeat/$PACKAGE && \
+RUN apk add --update --no-cache libc6-compat tar && \
     tar --strip-components=1 -zxf /opt/filebeat/"$PACKAGE" && \
     rm -f "$PACKAGE" && \
     wget -P /etc/pki/tls/certs/ https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY filebeat-yml-script.py docker-colletor-logs/filebeat-yml-script.py
 COPY $PACKAGE $PACKAGE
 
 RUN apk add --update --no-cache libc6-compat tar && \
-    tar --strip-components=1 -zxf /opt/filebeat/"$PACKAGE" && \
+    tar -zxf /opt/filebeat/"$PACKAGE" && \
     rm -f "$PACKAGE" && \
     wget -P /etc/pki/tls/certs/ https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt && \
     pip3 install -r ./docker-colletor-logs/requirements.txt --user && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm32v7/python:3.7-alpine
 
-ENV PACKAGE=filebeat-6.5.4-linux-arm32v7.tar.gz
+ENV PACKAGE=filebeat-6.5.4-arm32v7.tar.gz
 
 
 RUN mkdir -p /opt/filebeat/docker-colletor-logs && \


### PR DESCRIPTION
I could no find pre-built filebeat arm32v7 binary, so i add to build one myself by following https://github.com/oscarlpez/filebeat-6.6.0-armv7 and commit it directly in the repo...